### PR TITLE
Fix Version Flag Error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "quicknav"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quicknav"
 description = "A way to quickly navigate your filesystem from the command line."
-version = "1.0.0"
+version = "1.0.1"
 authors = ["MrDogeBro <MrDogeBro@users.noreply.github.com>"]
 license = "MIT"
 readme = "README.md"

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod utils;
 use anyhow::{anyhow, Result};
 use colored::*;
 use quicknav::Quicknav;
+use structopt::clap::ErrorKind;
 use structopt::StructOpt;
 
 fn main() {
@@ -51,6 +52,13 @@ fn run() -> Result<i32> {
             Quicknav::Config { option, new_value } => return commands::config(option, new_value),
             Quicknav::Init { shell, command } => return commands::init(shell, command),
         },
-        Err(e) => return Err(anyhow!(e)),
+        Err(e) => {
+            if e.kind == ErrorKind::VersionDisplayed {
+                println!("");
+                return Ok(0);
+            }
+
+            return Err(anyhow!(e));
+        }
     }
 }


### PR DESCRIPTION
Fixes a bug that was introduced when handling outputting errors. The version flag apparently is an error according to clap even though it still outputs the version. A check has now been put in place to stop this from erroring like it previously did.

## Closes

- Closes #15