### PR TITLE
Dev 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "quicknav"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quicknav"
 description = "A way to quickly navigate your filesystem from the command line."
-version = "1.1.0"
+version = "1.1.1"
 authors = ["MrDogeBro <MrDogeBro@users.noreply.github.com>"]
 license = "MIT"
 readme = "README.md"

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use colored::*;
 use std::env;
+use std::fs;
 
 use crate::config;
 
@@ -23,7 +24,7 @@ pub fn add(
 
     let mut shortcut_name: String = shortcut.to_string();
     let mut shortcut_description: String = shortcut.to_string();
-    let mut shortcut_location = location.to_string();
+    let shortcut_location: String;
     let cwd = env::current_dir().unwrap().display().to_string();
 
     if let Some(name) = name {
@@ -38,6 +39,12 @@ pub fn add(
         shortcut_location = cwd;
     } else if location.starts_with(&env::var("HOME").unwrap()) {
         shortcut_location = str::replace(&location, &env::var("HOME").unwrap(), "~");
+    } else {
+        shortcut_location = str::replace(
+            &fs::canonicalize(location)?.display().to_string(),
+            &env::var("HOME").unwrap(),
+            "~",
+        );
     }
 
     let new_shortcut = config::Shortcut {


### PR DESCRIPTION
Fixes a bug where relative paths were not correctly added to the config via the `quicknav add` command (#23). They are not expanded into their full path (including symlinks) so that they can be added via relative but accessed from anywhere.