### PR TITLE
Move Twords Using Shortcut Names

### DIFF
--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -68,7 +68,7 @@ pub fn add_call(shortcut: String, call: String) -> Result<i32> {
     let mut shortcut_index: usize = 0;
 
     for (i, shortcut_conf) in &mut config.shortcuts.iter().enumerate() {
-        if shortcut_conf.calls.iter().any(|c| c == &shortcut) {
+        if shortcut_conf.name.to_lowercase() == shortcut.to_lowercase() {
             found_shortcut = true;
             shortcut_index = i;
         }
@@ -76,7 +76,7 @@ pub fn add_call(shortcut: String, call: String) -> Result<i32> {
 
     if !found_shortcut {
         return Err(anyhow!(format!(
-            "Shortcut with call {} was not found.",
+            "Shortcut with name {} was not found.",
             shortcut,
         )));
     }

--- a/src/commands/add.rs
+++ b/src/commands/add.rs
@@ -6,7 +6,7 @@ use std::fs;
 use crate::config;
 
 pub fn add(
-    shortcut: String,
+    call: String,
     location: String,
     name: Option<String>,
     description: Option<String>,
@@ -14,16 +14,17 @@ pub fn add(
     let mut config: config::Config = config::Config::load()?;
 
     for shortcut_conf in &mut config.shortcuts {
-        if shortcut_conf.calls.iter().any(|c| c == &shortcut) {
+        if shortcut_conf.calls.iter().any(|c| c == &call) {
             return Err(anyhow!(format!(
                 "Shortcut with call {} already exists. Consider using {}.",
-                &shortcut, format!("quicknav edit {}", &shortcut).yellow()
+                &call,
+                format!("quicknav edit {}", &call).yellow()
             )));
         }
     }
 
-    let mut shortcut_name: String = shortcut.to_string();
-    let mut shortcut_description: String = shortcut.to_string();
+    let mut shortcut_name: String = call.to_string();
+    let mut shortcut_description: String = call.to_string();
     let shortcut_location: String;
     let cwd = env::current_dir().unwrap().display().to_string();
 
@@ -51,12 +52,12 @@ pub fn add(
         name: shortcut_name,
         description: shortcut_description,
         location: shortcut_location,
-        calls: vec![shortcut.to_string()],
+        calls: vec![call.to_string()],
     };
 
     config.shortcuts.push(new_shortcut);
     config.update()?;
-    println!("{} {}", "New shortcut added:".green(), &shortcut);
+    println!("{} {}", "New shortcut added:".green(), &call);
 
     Ok(0)
 }

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -17,11 +17,11 @@ pub fn edit(
     let mut valid_shortcut = false;
 
     for shortcut_conf in &mut config.shortcuts {
-        if shortcut_conf.name == shortcut {
+        if shortcut_conf.name.to_lowercase() == shortcut.to_lowercase() {
             valid_shortcut = true;
 
             if let (None, None, None) = (&location, &name, &description) {
-                return Err(anyhow!("No data was provided to edit {}.", &shortcut));
+                return Err(anyhow!("No data was provided to edit {}.", shortcut));
             }
 
             match &name {

--- a/src/commands/edit.rs
+++ b/src/commands/edit.rs
@@ -11,26 +11,24 @@ pub fn edit(
     name: Option<String>,
     description: Option<String>,
 ) -> Result<i32> {
-
-    if let (None, None, None) = (&location, &name, &description) {
-        return Err(anyhow!("No data was provided to edit {}.", &shortcut));
-    }
-
     let cwd = env::current_dir().unwrap().display().to_string();
     let mut config = config::Config::load()?;
     let mut res = "Shortcut edited: ".green().to_string();
     let mut valid_shortcut = false;
 
     for shortcut_conf in &mut config.shortcuts {
-        if shortcut_conf.calls.iter().any(|c| c == &shortcut) {
-
+        if shortcut_conf.name == shortcut {
             valid_shortcut = true;
+
+            if let (None, None, None) = (&location, &name, &description) {
+                return Err(anyhow!("No data was provided to edit {}.", &shortcut));
+            }
 
             match &name {
                 Some(n) => {
                     shortcut_conf.name = n.to_owned();
                     res.push_str(n);
-                },
+                }
                 _ => res.push_str(&shortcut_conf.name),
             }
 
@@ -38,9 +36,8 @@ pub fn edit(
                 if location == "." {
                     shortcut_conf.location = cwd.to_owned();
                 } else if location.starts_with(&env::var("HOME").unwrap()) {
-                    shortcut_conf.location = str::replace(
-                        &location, &env::var("HOME").unwrap(), "~"
-                    );
+                    shortcut_conf.location =
+                        str::replace(&location, &env::var("HOME").unwrap(), "~");
                 } else {
                     shortcut_conf.location = str::replace(
                         &fs::canonicalize(location)?.display().to_string(),
@@ -61,7 +58,7 @@ pub fn edit(
 
     if !valid_shortcut {
         return Err(anyhow!(format!(
-            "Shortcut with call {} was not found.",
+            "Shortcut with name {} was not found.",
             shortcut,
         )));
     }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -9,12 +9,12 @@ pub fn list(shortcut: Option<String>) -> Result<i32> {
 
         let mut shortcut_list = Table::new();
         shortcut_list.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
-        shortcut_list.set_titles(row!["Shortcuts", "Shortcut Name", "Shortcut Location"]);
+        shortcut_list.set_titles(row!["Name", "Shortcuts", "Shortcut Location"]);
 
         for shortcut_conf in config.shortcuts {
             if shortcut_conf.name.to_lowercase() == shortcut.to_lowercase() {
                 let calls: String = shortcut_conf.calls.join(", ");
-                shortcut_list.add_row(row![calls, shortcut_conf.name, shortcut_conf.location]);
+                shortcut_list.add_row(row![shortcut_conf.name, calls, shortcut_conf.location]);
                 shortcut_list.printstd();
                 return Ok(0);
             }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -29,11 +29,11 @@ pub fn list(shortcut: Option<String>) -> Result<i32> {
 
         let mut shortcut_list = Table::new();
         shortcut_list.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
-        shortcut_list.set_titles(row!["Shortcuts", "Shortcut Name", "Shortcut Location"]);
+        shortcut_list.set_titles(row!["Name", "Shortcuts", "Shortcut Location"]);
 
         for shortcut_conf in config.shortcuts {
             let calls: String = shortcut_conf.calls.join(", ");
-            shortcut_list.add_row(row![calls, shortcut_conf.name, shortcut_conf.location]);
+            shortcut_list.add_row(row![shortcut_conf.name, calls, shortcut_conf.location]);
         }
 
         shortcut_list.printstd();

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -4,7 +4,7 @@ use prettytable::{format, Table};
 use crate::config;
 
 pub fn list(shortcut: Option<String>) -> Result<i32> {
-    if let Some(call) = shortcut {
+    if let Some(shortcut) = shortcut {
         let config: config::Config = config::Config::load()?;
 
         let mut shortcut_list = Table::new();
@@ -12,7 +12,7 @@ pub fn list(shortcut: Option<String>) -> Result<i32> {
         shortcut_list.set_titles(row!["Shortcuts", "Shortcut Name", "Shortcut Location"]);
 
         for shortcut_conf in config.shortcuts {
-            if shortcut_conf.calls.iter().any(|c| c == &call) {
+            if shortcut_conf.name.to_lowercase() == shortcut.to_lowercase() {
                 let calls: String = shortcut_conf.calls.join(", ");
                 shortcut_list.add_row(row![calls, shortcut_conf.name, shortcut_conf.location]);
                 shortcut_list.printstd();
@@ -21,8 +21,8 @@ pub fn list(shortcut: Option<String>) -> Result<i32> {
         }
 
         Err(anyhow!(format!(
-            "Could not find shortcut with a call of {}.",
-            call
+            "Shortcut with name {} was not found",
+            shortcut
         )))
     } else {
         let config: config::Config = config::Config::load()?;

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -9,7 +9,7 @@ pub fn remove(shortcut: String) -> Result<i32> {
     let mut index_to_remove: usize = 0;
 
     for (i, shortcut_conf) in &mut config.shortcuts.iter().enumerate() {
-        if shortcut_conf.calls.iter().any(|c| c == &shortcut) {
+        if shortcut_conf.name.to_lowercase() == shortcut.to_lowercase() {
             found_shortcut = true;
             index_to_remove = i;
         }
@@ -59,7 +59,7 @@ pub fn remove_call(call: String) -> Result<i32> {
         return Err(anyhow!(format!(
             "Shortcuts must have one call. Please either add a new call before trying to remove one or remove the whole shortcut using {} {}",
             "quicknav remove".yellow(),
-            call.yellow(),
+            config.shortcuts[shortcut_index].name.yellow(),
         )));
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,11 +58,11 @@ fn run() -> Result<i32> {
             Quicknav::Get { location, search } => return commands::get(location, search),
             Quicknav::List { shortcut } => return commands::list(shortcut),
             Quicknav::Add {
-                shortcut,
+                call,
                 location,
                 name,
                 description,
-            } => return commands::add(shortcut, location, name, description),
+            } => return commands::add(call, location, name, description),
             Quicknav::Edit {
                 shortcut,
                 location,

--- a/src/quicknav.rs
+++ b/src/quicknav.rs
@@ -14,14 +14,14 @@ pub enum Quicknav {
     /// Lists the registered shortcuts
     #[structopt(alias = "ls")]
     List {
-        /// The shortcut to search for
+        /// The shortcut to search for (by name)
         shortcut: Option<String>,
     },
     /// Adds a new shortcut
     #[structopt(alias = "new")]
     Add {
         /// The shortcut itself (call)
-        shortcut: String,
+        call: String,
         /// The shortcut location
         location: String,
         /// The shortcut name
@@ -35,29 +35,29 @@ pub enum Quicknav {
     /// shortcut
     #[structopt(alias = "new-call")]
     AddCall {
-        /// One of the calls for the shortcut
-        /// you are trying to add on to
+        /// The shortcut you are trying to
+        /// add a call to (by name)
         shortcut: String,
         /// The call you want to be added
         call: String,
     },
     /// Edits an existing shortcut
     Edit {
-        /// The shortcut itself (call)
+        /// The shortcut to edit (by name)
         shortcut: String,
-        /// The shortcut location
+        /// The new shortcut location
         location: Option<String>,
-        /// The shortcut name
+        /// The new shortcut name
         #[structopt(short = "n", long = "name")]
         name: Option<String>,
-        /// The shortcut description
+        /// The new shortcut description
         #[structopt(short = "d", long = "description")]
         description: Option<String>,
     },
     /// Removes a shortcut
     #[structopt(aliases = &["rm", "del", "delete"])]
     Remove {
-        /// The shortcut to remove (by call)
+        /// The shortcut to remove (by name)
         shortcut: String,
     },
     /// Removes a call for an existing


### PR DESCRIPTION
## Summary

This PR moves more twords using shortcut names instead of shortcut calls in commands as a part of the upcoming 1.3 release. This also helps to add a purpose for the name param in the config. As a part of these changes, the help messages have been updated slightly for clarity and a few of the param names have also been updated for clarity. This also makes the shortcut params case insensitive.

This also includes a slight update to the edit command. It moves the no data provided error inside of the if block so it only triggers if a valid shortcut is found. This way, the invalid shortcut error is displayed first before the no data provided error.

## Closes

- Closes #29