### PR TITLE
Implement -q flag for quicknav list

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ quicknav init fish | source
 
 ## Docs
 
-For more info on quicknav such as cofiguration, [head over to our docs](https://quicknav.readthedocs.io/) where you can find all of the
+For more info on quicknav such as configuration, [head over to our docs](https://quicknav.readthedocs.io/) where you can find all of the
 information you might need.
 
 ## License

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -3,46 +3,60 @@ use prettytable::{format, Table};
 
 use crate::config;
 
-pub fn list(shortcut: Option<String>) -> Result<i32> {
-    if let Some(shortcut) = shortcut {
-        let config: config::Config = config::Config::load()?;
-
-        let mut shortcut_list = Table::new();
-        shortcut_list.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
-        shortcut_list.set_titles(row!["Name", "Shortcuts", "Shortcut Location"]);
-
+fn get_relevant_shortcuts(
+    shortcut: Option<String>,
+    config: config::Config,
+) -> Result<Vec<config::Shortcut>> {
+    if let Some(shortcut_name) = shortcut {
         for shortcut_conf in config.shortcuts {
-            if shortcut_conf.name.to_lowercase() == shortcut.to_lowercase() {
-                let calls: String = shortcut_conf.calls.join(", ");
-                shortcut_list.add_row(row![shortcut_conf.name, calls, shortcut_conf.location]);
-                shortcut_list.printstd();
-                return Ok(0);
+            if shortcut_conf.name == shortcut_name {
+                return Ok(vec![shortcut_conf]);
             }
         }
 
-        Err(anyhow!(format!(
+        return Err(anyhow!(format!(
             "Shortcut with name {} was not found",
-            shortcut
-        )))
+            shortcut_name
+        )));
+    }
+
+    Ok(config.shortcuts)
+}
+
+fn display_in_table(shortcut: Option<String>, config: config::Config) -> Result<i32> {
+    let mut shortcut_list = Table::new();
+    shortcut_list.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
+    shortcut_list.set_titles(row!["Name", "Shortcuts", "Shortcut Location"]);
+
+    for shortcut_conf in get_relevant_shortcuts(shortcut, config)? {
+        let calls: String = shortcut_conf.calls.join(", ");
+        shortcut_list.add_row(row![shortcut_conf.name, calls, shortcut_conf.location]);
+    }
+
+    shortcut_list.printstd();
+    Ok(0)
+}
+
+fn display_quiet(shortcut: Option<String>, config: config::Config) -> Result<i32> {
+    for shortcut_conf in get_relevant_shortcuts(shortcut, config)? {
+        println!("{}", shortcut_conf.location);
+    }
+
+    Ok(0)
+}
+
+pub fn list(shortcut: Option<String>, quiet: bool) -> Result<i32> {
+    let config: config::Config = config::Config::load()?;
+
+    if config.shortcuts.is_empty() {
+        return Err(anyhow!(
+            "You haven't set up any shortcuts yet, get started with quicknav add."
+        ));
+    }
+
+    if quiet {
+        display_quiet(shortcut, config)
     } else {
-        let config: config::Config = config::Config::load()?;
-
-        if config.shortcuts.is_empty() {
-            return Err(anyhow!(
-                "You haven't set up any shortcuts yet, get started with quicknav add."
-            ));
-        }
-
-        let mut shortcut_list = Table::new();
-        shortcut_list.set_format(*format::consts::FORMAT_NO_BORDER_LINE_SEPARATOR);
-        shortcut_list.set_titles(row!["Name", "Shortcuts", "Shortcut Location"]);
-
-        for shortcut_conf in config.shortcuts {
-            let calls: String = shortcut_conf.calls.join(", ");
-            shortcut_list.add_row(row![shortcut_conf.name, calls, shortcut_conf.location]);
-        }
-
-        shortcut_list.printstd();
-        Ok(0)
+        display_in_table(shortcut, config)
     }
 }

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -9,7 +9,7 @@ fn get_relevant_shortcuts(
 ) -> Result<Vec<config::Shortcut>> {
     if let Some(shortcut_name) = shortcut {
         for shortcut_conf in config.shortcuts {
-            if shortcut_conf.name == shortcut_name {
+            if shortcut_conf.name.to_lowercase() == shortcut_name.to_lowercase() {
                 return Ok(vec![shortcut_conf]);
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn run() -> Result<i32> {
     match Quicknav::from_args_safe() {
         Ok(cmd) => match cmd {
             Quicknav::Get { location, search } => commands::get(location, search),
-            Quicknav::List { shortcut } => commands::list(shortcut),
+            Quicknav::List { shortcut, quiet } => commands::list(shortcut, quiet),
             Quicknav::Add {
                 call,
                 location,

--- a/src/quicknav.rs
+++ b/src/quicknav.rs
@@ -16,6 +16,9 @@ pub enum Quicknav {
     List {
         /// The shortcut to search for (by name)
         shortcut: Option<String>,
+        /// Display only the shortcut path
+        #[structopt(short = "q", long = "quiet")]
+        quiet: bool,
     },
     /// Adds a new shortcut
     #[structopt(alias = "new")]


### PR DESCRIPTION
## Summary

This PR adds a `-q` and `--quiet` flag to the `quicknav list` subcommand.
I tried to reduce the code duplication in that file as there was going to be like 3x duplication of some blocks.
Let me know if you can see any additional optimizations.

It also fixes a typo in the readme.

On a side note, we should think about rewording the PR template checklist, as the majority of documentation is no longer in the readme.

Examples:
```bash
# With no shortcut, it lists all the paths

$ quicknav ls -q
/home/user/projects/py
/home/user/projects/rs
/home/user/projects/cpp
/home/user/projects/quicknav
[...]
```

```bash
# With a shortcut, it just lists that shortcuts path

$ quicknav ls qn -q
/home/user/projects/quicknav
```

```bash
# Errors when an invalid shortcut is used.

$ quicknav ls nonexistentshortcut -q
Error: Shortcut with name nonexistentshortcut was not found
```

## Checklist

<!-- [ ] = no, [x] = yes -->

- [x] I have completed the following checklist.
- I have searched for similar/duplicate PR's, and there are none.
- If this is a **source code update** (main code base changed):
  - I have documented my changes in the README.
  - I have created unit tests for the modified code base.
  - All tests pass (if not please elaborate).
